### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build code image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -18,7 +18,7 @@ jobs:
           tags: "latest,code"
           dockerfile: deploy/Dockerfile.CODE
       - name: build debug code image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build debug code image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: build runtime image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -19,7 +19,7 @@ jobs:
           dockerfile: deploy/Dockerfile.RUNTIME
 
       - name: build nginx image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -28,7 +28,7 @@ jobs:
           dockerfile: deploy/Dockerfile.NGINX
 
       - name: build debug runtime
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ssr.yaml
+++ b/.github/workflows/ssr.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: build ssr image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build tag image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/django-sspanel
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore